### PR TITLE
Add shortcuts for (v)splits

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,22 @@ nmap <unique> <C-\>e :cs find e <C-R>=expand("<cword>")<CR><CR>
 nmap <unique> <C-\>f :cs find f <C-R>=expand("<cfile>")<CR><CR>
 nmap <unique> <C-\>i :cs find i ^<C-R>=expand("<cfile>")<CR>$<CR>
 nmap <unique> <C-\>d :cs find d <C-R>=expand("<cword>")<CR><CR>
+nmap <unique> <C-Space>s :scs find s <C-R>=expand("<cword>")<CR><CR>
+nmap <unique> <C-Space>g :scs find g <C-R>=expand("<cword>")<CR><CR>
+nmap <unique> <C-Space>c :scs find c <C-R>=expand("<cword>")<CR><CR>
+nmap <unique> <C-Space>t :scs find t <C-R>=expand("<cword>")<CR><CR>
+nmap <unique> <C-Space>e :scs find e <C-R>=expand("<cword>")<CR><CR>
+nmap <unique> <C-Space>f :scs find f <C-R>=expand("<cfile>")<CR><CR>
+nmap <unique> <C-Space>i :scs find i ^<C-R>=expand("<cfile>")<CR>$<CR>
+nmap <unique> <C-Space>d :scs find d <C-R>=expand("<cword>")<CR><CR>
+nmap <unique> <C-Space><C-Space>s :vert scs find s <C-R>=expand("<cword>")<CR><CR>
+nmap <unique> <C-Space><C-Space>g :vert scs find g <C-R>=expand("<cword>")<CR><CR>
+nmap <unique> <C-Space><C-Space>c :vert scs find c <C-R>=expand("<cword>")<CR><CR>
+nmap <unique> <C-Space><C-Space>t :vert scs find t <C-R>=expand("<cword>")<CR><CR>
+nmap <unique> <C-Space><C-Space>e :vert scs find e <C-R>=expand("<cword>")<CR><CR>
+nmap <unique> <C-Space><C-Space>f :vert scs find f <C-R>=expand("<cfile>")<CR><CR>
+nmap <unique> <C-Space><C-Space>i :vert scs find i ^<C-R>=expand("<cfile>")<CR>$<CR>
+nmap <unique> <C-Space><C-Space>d :vert scs find d <C-R>=expand("<cword>")<CR><CR>
 ```
 
 

--- a/rplugin/python/nvim-cscope.py
+++ b/rplugin/python/nvim-cscope.py
@@ -128,6 +128,40 @@ class CScope(object):
             'nmap <unique> <C-\>i :cs find i ^<C-R>=expand("<cfile>")<CR><CR>')
         self.nvim.command(
             'nmap <unique> <C-\>d :cs find d <C-R>=expand("<cword>")<CR><CR>')
+        self.nvim.command(
+            'nmap <unique> <C-Space>s :scs find s <C-R>=expand("<cword>")<CR><CR>')
+        self.nvim.command(
+            'nmap <unique> <C-Space>g :scs find g <C-R>=expand("<cword>")<CR><CR>')
+        self.nvim.command(
+            'nmap <unique> <C-Space>c :scs find c <C-R>=expand("<cword>")<CR><CR>')
+        self.nvim.command(
+            'nmap <unique> <C-Space>t :scs find t <C-R>=expand("<cword>")<CR><CR>')
+        self.nvim.command(
+            'nmap <unique> <C-Space>e :scs find e <C-R>=expand("<cword>")<CR><CR>')
+        self.nvim.command(
+            'nmap <unique> <C-Space>f :scs find f <C-R>=expand("<cfile>")<CR><CR>')
+        self.nvim.command(
+            'nmap <unique> <C-Space>i :scs find i ^<C-R>=expand("<cfile>")<CR><CR>')
+        self.nvim.command(
+            'nmap <unique> <C-Space>d :scs find d <C-R>=expand("<cword>")<CR><CR>')
+        self.nvim.command(
+            'nmap <unique> <C-Space><C-Space>s :vert scs find s <C-R>=expand("<cword>")<CR><CR>')
+        self.nvim.command(
+            'nmap <unique> <C-Space><C-Space>g :vert scs find g <C-R>=expand("<cword>")<CR><CR>')
+        self.nvim.command(
+            'nmap <unique> <C-Space><C-Space>c :vert scs find c <C-R>=expand("<cword>")<CR><CR>')
+        self.nvim.command(
+            'nmap <unique> <C-Space><C-Space>t :vert scs find t <C-R>=expand("<cword>")<CR><CR>')
+        self.nvim.command(
+            'nmap <unique> <C-Space><C-Space>e :vert scs find e <C-R>=expand("<cword>")<CR><CR>')
+        self.nvim.command(
+            'nmap <unique> <C-Space><C-Space>f :vert scs find f <C-R>=expand("<cfile>")<CR><CR>')
+        self.nvim.command(
+            'nmap <unique> <C-Space><C-Space>i :vert scs find i ^<C-R>=expand("<cfile>")<CR><CR>')
+        self.nvim.command(
+            'nmap <unique> <C-Space><C-Space>d :vert scs find d <C-R>=expand("<cword>")<CR><CR>')
+        self.nvim.command(
+            'imap <C-@> <C-Space>')
 
     @neovim.command('CScopeUpdate', range='', nargs='*', sync=False)
     def cscope_update_files_handler(self, args, range):


### PR DESCRIPTION
Add shortcuts for splits and vertical splits by replacing CTRL+\ with
CRTL+<space> for horizontal and CRTL+<space>+<space> for vertical
splits.