### PR TITLE
Switch to full python3 support with additional feature for external libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ inside of subfolders, depending on the given project name.
 
 ## Installation
 
-**Note:** cscope.nvim requires Neovim with python enabled.
+**Note:** cscope.nvim requires Neovim with python3 enabled.
 
 1. Extract the files and put them in your Neovim directory
-   ('$XDG_CONFIG_HOME/nvim/rplugin/python/').
+   ('$XDG_CONFIG_HOME/nvim/rplugin/python3/').
 2. Inside nvim run ':UpdateRemotePlugins' and restart nvim
 
 For vim-plug

--- a/README.md
+++ b/README.md
@@ -91,4 +91,9 @@ path = ~/Projects/cscope.nvim
 
 # File patterns to scan
 files = *.h,*.c,*.hh,*.cc
+
+# External libraries for find to search extra files (optional)
+libs =
+    ~/.tools/external-sdk
+    /usr/local/libraries/usb
 ```

--- a/README.md
+++ b/README.md
@@ -89,6 +89,6 @@ name = Example
 # Where find will start searching the files.
 path = ~/Projects/cscope.nvim
 
-# file patterns to scan
+# File patterns to scan
 files = *.h,*.c,*.hh,*.cc
 ```

--- a/README.md
+++ b/README.md
@@ -8,9 +8,14 @@ inside of subfolders, depending on the given project name.
 ## Installation
 
 **Note:** cscope.nvim requires Neovim with python3 enabled.
+
+1. Extract the files and put them in your Neovim directory
+   ('$XDG_CONFIG_HOME/nvim/rplugin/python3/').
+2. Inside nvim run ':UpdateRemotePlugins' and restart nvim
+
 For vim-plug
 ```
-Plug 'mfulz/cscope.nvim', { 'do': 'UpdateRemotePlugins' }
+Plug 'mfulz/cscope.nvim'
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -8,14 +8,9 @@ inside of subfolders, depending on the given project name.
 ## Installation
 
 **Note:** cscope.nvim requires Neovim with python3 enabled.
-
-1. Extract the files and put them in your Neovim directory
-   ('$XDG_CONFIG_HOME/nvim/rplugin/python3/').
-2. Inside nvim run ':UpdateRemotePlugins' and restart nvim
-
 For vim-plug
 ```
-Plug 'mfulz/cscope.nvim'
+Plug 'mfulz/cscope.nvim', { 'do': 'UpdateRemotePlugins' }
 ```
 
 ## Configuration

--- a/rplugin/python3/nvim-cscope.py
+++ b/rplugin/python3/nvim-cscope.py
@@ -2,13 +2,8 @@ import neovim
 import os
 import sys
 import subprocess
-if sys.version_info > (3, 0):
-    import configparser
-    ConfigParser = configparser
-    from io import StringIO
-else:
-    import ConfigParser
-    from StringIO import StringIO
+import configparser
+from io import StringIO
 
 
 @neovim.plugin
@@ -21,7 +16,7 @@ class CScope(object):
     def __parse_config(self):
         self.config = dict()
 
-        config = ConfigParser.ConfigParser()
+        config = configparser.ConfigParser()
         with open(self.project_conf) as stream:
             stream = StringIO("[root]\n" + stream.read())
             config.readfp(stream)
@@ -31,7 +26,7 @@ class CScope(object):
             self.config['project_path'] = os.path.expanduser(
                 config.get('root', 'path'))
             self.config['file_types'] = config.get('root', 'files')
-        except ConfigParser.NoOptionError as e:
+        except configparser.NoOptionError as e:
             return (
                 False,
                 "Error parsing file: '{0}': {1}".format(

--- a/rplugin/python3/nvim-cscope.py
+++ b/rplugin/python3/nvim-cscope.py
@@ -25,7 +25,7 @@ class CScope(object):
             self.config['project_name'] = config.get('root', 'name')
             self.config['project_path'] = os.path.expanduser(
                 config.get('root', 'path'))
-            self.config['file_types'] = config.get('root', 'files')
+            self.config['file_types'] = config.get('root', 'files').split(',')
         except configparser.NoOptionError as e:
             return (
                 False,
@@ -61,7 +61,7 @@ class CScope(object):
         if self.cscope_ready:
             cmd = ['find']
             first = True
-            for file_type in self.config['file_types'].split(','):
+            for file_type in self.config['file_types']:
                 if first:
                     cmd.append(self.config['project_path'])
                     first = False

--- a/rplugin/python3/nvim-cscope.py
+++ b/rplugin/python3/nvim-cscope.py
@@ -26,6 +26,10 @@ class CScope(object):
             self.config['project_path'] = os.path.expanduser(
                 config.get('root', 'path'))
             self.config['file_types'] = config.get('root', 'files').split(',')
+            self.config['project_libs'] = [
+                os.path.expanduser(l)
+                for l in config.get('root', 'libs', fallback='').split('\n')
+                if l != '' ]
         except configparser.NoOptionError as e:
             return (
                 False,
@@ -60,6 +64,8 @@ class CScope(object):
         self.cmd_cscope_files = None
         if self.cscope_ready:
             cmd = ['find']
+            for lib_path in self.config['project_libs']:
+                cmd.append(lib_path)
             first = True
             for file_type in self.config['file_types']:
                 if first:

--- a/rplugin/python3/nvim-cscope.py
+++ b/rplugin/python3/nvim-cscope.py
@@ -216,7 +216,8 @@ class CScope(object):
                     os.getcwd(), self.nvim.vars['cscope_config'])
             else:
                 self.nvim.command(
-                    'echo "Couldn\'t start CScope: \'cscope.py\' does not exist."')
+                    'echo "Couldn\'t start CScope: \'{0}\' does not exist."'.format(
+                        self.nvim.vars['cscope_config']))
                 return
 
         check = self.__parse_config()


### PR DESCRIPTION
Hi @mfulz !

Thanks for this great plugin 👍!

I've been a user for quite a long time. I do use your plugin in my daily workflow for embedded system development on macOS. Since Catalina release, `python2` is still the default version shipped by Apple, but Homebrew has deprecated its installation. Hence, only `python3` furnishes the `pip` tool to manage python dependencies.

FYI, here is what `:checkhealth` reports about python provider.

```
## Python 2 provider (optional)
  - WARNING: No Python executable found that can `import neovim`. Using the first available executable for diagnostics.
  - ERROR: Python provider error:
    - ADVICE:
      - provider/pythonx: Could not load Python 2:
          /usr/bin/python2 does not have the "neovim" module. :help |provider-python|
          /usr/bin/python2.7 does not have the "neovim" module. :help |provider-python|
          python2.6 not found in search path or not executable.
          /usr/local/opt/python3/libexec/bin/python is Python 3.7 and cannot provide Python 2.
  - INFO: Executable: Not found

## Python 3 provider (optional)
  - INFO: `g:python3_host_prog` is not set.  Searching for python3 in the environment.
  - INFO: Multiple python3 executables found.  Set `g:python3_host_prog` to avoid surprises.
  - INFO: Executable: /usr/local/bin/python3
  - INFO: Other python executable: /usr/bin/python3
  - INFO: Python version: 3.7.7
  - INFO: pynvim version: 0.4.1
  - OK: Latest pynvim is installed.
```

As per `Neovim Remote Plugins`, the folder name matters so it knows which python version to use for the plugin. Hence, and as I embrace `python2`'s deprecation as per January 2020, I totally removed its support and fully went for `python3`. Without doing so, and because there is no `pynvim` install for `python2`, `:UpdateRemotePlugins` throws an error because of `cscope.nvim`. The plugin is no more loaded and there is no command available 😢 

When developing embedded systems, I often rely on external libraries and SDKs furnishing source code. I very much appreciate having these files processed by `cscope`.

This PR is mainly for communication purposes and in case someone finds it useful. I would very much appreciate your feedback regarding this use case and python2's deprecation.

All the best,
Hugo